### PR TITLE
add SVG conversion wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@
 
 # Service integration id
 APP_ID = template
-# Dependencies
-DEPS = rsvg-convert
 # Default installation destination
 DEST ?= $(HOME)/.local/share/nuvolaplayer3/web_apps
 # Sizes of the whole icon set
@@ -40,19 +38,14 @@ SCALABLE_ICON = $(ICONS_DIR)/scalable.svg
 
 # Show help
 help:
-	@echo "make deps                - check whether dependencies are satisfied"
 	@echo "make build               - build files (graphics, etc.)"
 	@echo "make clean               - clean source directory"
 	@echo "make install             - install to user's local directory (~/.local)"
 	@echo "make install DEST=/path  - install to '/path' directory"
 	@echo "make uninstall           - uninstall from user's local directory (~/.local)"
 
-# Check dependencies
-deps:
-	@$(foreach dep, $(DEPS), which $(dep) > /dev/null || (echo "Program $(dep) not found"; exit 1;);)
-
 # Build icons
-build: deps $(PNG_ICONS) $(SCALABLE_ICON)
+build: $(PNG_ICONS) $(SCALABLE_ICON)
 
 # Create icons dir
 $(ICONS_DIR):
@@ -60,27 +53,27 @@ $(ICONS_DIR):
 	
 # Generate icon 16
 $(ICONS_DIR)/16.png: $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 16 -h 16 $< -o $@
+	./svg-convert.sh $< 16 $@
 
 # Generate icon 22	
 $(ICONS_DIR)/22.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 22 -h 22 $< -o $@
+	./svg-convert.sh $< 22 $@
 
 # Generate icon 24	
 $(ICONS_DIR)/24.png : $(SOURCE_ICON_XS) | $(ICONS_DIR)
-	rsvg-convert -w 24 -h 24 $< -o $@
+	./svg-convert.sh $< 24 $@
 
 # Generate icon 32	
 $(ICONS_DIR)/32.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -w 32 -h 32 $< -o $@
+	./svg-convert.sh $< 32 $@
 
 # Generate icon 48
 $(ICONS_DIR)/48.png : $(SOURCE_ICON_SM) | $(ICONS_DIR)
-	rsvg-convert -w 48 -h 48 $< -o $@
+	./svg-convert.sh $< 48 $@
 
 # Generate icons 64 128 256
 $(ICONS_DIR)/%.png : $(SOURCE_ICON) | $(ICONS_DIR)
-	rsvg-convert -w $* -h $* $< -o $@
+	./svg-convert.sh $< $* $@
 
 # Copy scalable icon
 $(SCALABLE_ICON) : $(SOURCE_ICON) | $(ICONS_DIR)
@@ -99,7 +92,7 @@ install: $(LICENSES) $(INSTALL_FILES) $(PNG_ICONS) $(SCALABLE_ICON)
 	
 	# Create symlinks to icons
 	mkdir -pv $(DEST)/../../icons/hicolor/scalable/apps || true
-	ln -s -f -v -T ../../../../$(APP_ID)/$(SCALABLE_ICON) \
+	ln -s -f -v -T ../../../../nuvolaplayer3/web_apps/$(APP_ID)/$(SCALABLE_ICON) \
 		$(DEST)/../../icons/hicolor/scalable/apps/nuvolaplayer3_$(APP_ID).svg;
 	for size in $(ICON_SIZES); do \
 		mkdir -pv $(DEST)/../../icons/hicolor/$${size}x$${size}/apps || true ; \

--- a/svg-convert.sh
+++ b/svg-convert.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# Copyright 2016 Patrick Burroughs (Celti) <celti@celti.name>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+source_file="$1"
+dest_size="$2"
+dest_file="$3"
+
+exists () {
+	type "$1" >/dev/null 2>/dev/null
+}
+
+divide () {
+	echo - | awk "{ print $1 / $2 }"
+}
+
+if exists lasem-render; then       # GNOME/Lasem
+	CONVERT=lasem-render
+elif exists lasem-render-0.4; then # GNOME/Lasem (current version May 2016)
+	CONVERT=lasem-render-0.4
+elif exists rsvg-convert; then     # librsvg (broken on Arch Linux as of May 2016)
+	CONVERT=rsvg-convert
+elif exists gm; then               # GraphicsMagick
+	CONVERT=gm
+elif exists convert; then          # ImageMagick
+	CONVERT=convert
+else
+	echo "No supported SVG converter found! (Tried: Lasem, librsvg, GraphicsMagick, ImageMagick)" >&2
+	exit 1
+fi
+
+case $CONVERT in
+	lasem-render*)
+		source_size=$($CONVERT --debug render "${source_file}" -o /dev/null | awk '/width/ { print $3 }')
+		zoom_factor=$(divide ${dest_size} ${source_size})
+		$CONVERT -z ${zoom_factor} "${source_file}" -o "${dest_file}"
+		;;
+	rsvg-convert)
+		$CONVERT -w ${dest_size} -h ${dest_size} "${source_file}" -o "${dest_file}"
+		;;
+	gm)
+		$CONVERT convert "${source_file}" -resize ${dest_size} "${dest_file}"
+		;;
+	convert)
+		$CONVERT "${source_file}" -resize ${dest_size} "${dest_file}"
+		;;
+esac


### PR DESCRIPTION
This replaces tiliado/nuvola-app-google-play-music#13 and tiliado/nuvola-app-google-play-music#14 in a fairly foolproof manner as you requested.

The added `./svg-convert.sh` is pure POSIX sh + awk (awk is required to calculate zoom factor floats in a simple fashion). It checks for, in order of preference: `lasem-render`, `lasem-render-0.4` (the default name of the binary), `rsvg-convert`, `gm` (GraphicsMagick), and `convert` (ImageMagick), and produces and runs the necessary command for whichever it finds and uses.

The Makefile, of course, is updated to use it, as well as with the symlink fix.
